### PR TITLE
feat(iam): add custom IAM policy for DevOps group (not yet attached)

### DIFF
--- a/aws/devops-access-policy.tf
+++ b/aws/devops-access-policy.tf
@@ -1,0 +1,80 @@
+# Retrieve AWS account ID dynamically
+data "aws_caller_identity" "current" {}
+
+# Define custom IAM policy for DevOps group
+resource "aws_iam_policy" "devops_policy" {
+  name        = "DevOpsPolicy"
+  path        = "/internal/"
+  description = "Custom IAM policy for DevOps group"
+
+  policy = jsonencode({
+	    Version = "2012-10-17",
+	    Statement = [
+	      { # Allow describing VPC and subnet resources
+	        Sid    = "VPCAndBasicInfra",
+	        Effect = "Allow",
+	        Action = [
+	          "ec2:DescribeVpcs",
+	          "ec2:DescribeSubnets",
+	          "ec2:CreateTags"
+	        ],
+	        Resource = "*"
+	      },
+	      { # Allow access to Terraform state in S3 bucket
+	        Sid    = "S3StateAccess",
+	        Effect = "Allow",
+	        Action = [
+	          "s3:GetObject",
+	          "s3:PutObject",
+	          "s3:ListBucket"
+	        ],
+	        Resource = [
+	          "arn:aws:s3:::${var.s3_bucket_name}",
+	          "arn:aws:s3:::${var.s3_bucket_name}/*"
+	        ]
+	      },
+	      { # Allow Terraform state locking with DynamoDB
+	        Sid    = "DynamoDBLocking",
+	        Effect = "Allow",
+	        Action = [
+	          "dynamodb:GetItem",
+	          "dynamodb:PutItem",
+	          "dynamodb:DeleteItem"
+	        ],
+	        Resource = "arn:aws:dynamodb:${var.aws_region}:${data.aws_caller_identity.current.account_id}:table/${var.dynamodb_table_name}"
+	      },
+	      { # Full access to AWS IoT Core
+	        Sid    = "IoTCoreAccess",
+	        Effect = "Allow",
+	        Action = [
+	          "iot:*"
+	        ],
+	        Resource = "*"
+	      },
+	      { # Full access to Lambda functions and logs
+	        Sid    = "LambdaAndLogs",
+	        Effect = "Allow",
+	        Action = [
+	          "lambda:*",
+	          "logs:*"
+	        ],
+	        Resource = "*"
+	      },
+	      { # Allow group-level IAM operations (for internal teams)
+			"Sid": "IAMGroupScoped",
+			"Effect": "Allow",
+			"Action": [
+			  "iam:CreateGroup",
+			  "iam:DeleteGroup",
+			  "iam:GetGroup",
+			  "iam:ListGroups",
+			  "iam:PutGroupPolicy",
+			  "iam:DeleteGroupPolicy",
+	  	      "iam:AttachGroupPolicy",
+			  "iam:DetachGroupPolicy"
+			],
+			"Resource": "*"	
+	 	  }
+	    ]
+	  })
+}

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -20,3 +20,12 @@ resource "aws_vpc" "cloud_notification_platform_network" {
     Name = "cloud-notification-platform-vpc"
   }
 }
+
+# ------------------- Internal IAM -----------------
+# Create internal groups
+resource "aws_iam_group" "teams" {
+	for_each 	=		toset(var.team_groups)
+	name 		=		each.key
+	path		=		"/internal/"
+}
+

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -1,7 +1,29 @@
 # ----------- AWS ------------
 
-variable "aws_region" {	type = string }
+variable "aws_region" {
+  type        = string
+  description = "The AWS region to deploy resources in"
+}
+
+variable "s3_bucket_name" {
+  type        = string
+  description = "Name of the S3 bucket used for Terraform remote state"
+}
+
+variable "dynamodb_table_name" {
+  type        = string
+  description = "Name of the DynamoDB table used for Terraform state locking"
+}
 
 # ----------- Common ------------
 
-variable "cidr_block" { type = string }
+variable "cidr_block" {
+  type        = string
+  description = "CIDR block for VPC"
+}
+
+variable "team_groups" {
+  type        = list(string)
+  default     = ["DevOps", "Developers", "Managers"]
+  description = "List of internal IAM groups used by the organisation"
+}


### PR DESCRIPTION
- Created jsonencoded policy in devops-access-policy.tf
- Added required input variables (S3 bucket, DynamoDB table)
- IAM group for DevOps defined, policy attachment pending